### PR TITLE
Fixed deprecation warnings.

### DIFF
--- a/usb_ser_mon/find_port.py
+++ b/usb_ser_mon/find_port.py
@@ -29,33 +29,33 @@ def is_usb_serial(device, vid=None, pid=None, vendor=None, serial=None, *args,
     If serial_num or vendor is provided, then it will further check to
     see if the serial number and vendor of the device also matches.
     """
-    if 'ID_VENDOR' not in device:
+    if 'ID_VENDOR' not in device.properties:
         return False
     if vid is not None:
-        if device['ID_VENDOR_ID'] != vid:
+        if device.properties['ID_VENDOR_ID'] != vid:
             return False
     if pid is not None:
-        if device['ID_MODEL_ID'] != pid:
+        if device.properties['ID_MODEL_ID'] != pid:
             return False
     if vendor is not None:
-        if 'ID_VENDOR' not in device:
+        if 'ID_VENDOR' not in device.properties:
             return False
-        if not device['ID_VENDOR'].startswith(vendor):
+        if not device.properties['ID_VENDOR'].startswith(vendor):
             return False
     if serial is not None:
-        if 'ID_SERIAL_SHORT' not in device:
+        if 'ID_SERIAL_SHORT' not in device.properties:
             return False
-        if not device['ID_SERIAL_SHORT'].startswith(serial):
+        if not device.properties['ID_SERIAL_SHORT'].startswith(serial):
             return False
     return True
 
 
 def extra_info(device):
     extra_items = []
-    if 'ID_VENDOR' in device:
-        extra_items.append("vendor '%s'" % device['ID_VENDOR'])
-    if 'ID_SERIAL_SHORT' in device:
-        extra_items.append("serial '%s'" % device['ID_SERIAL_SHORT'])
+    if 'ID_VENDOR' in device.properties:
+        extra_items.append("vendor '%s'" % device.properties['ID_VENDOR'])
+    if 'ID_SERIAL_SHORT' in device.properties:
+        extra_items.append("serial '%s'" % device.properties['ID_SERIAL_SHORT'])
     if extra_items:
         return ' with ' + ' '.join(extra_items)
     return ''
@@ -68,7 +68,7 @@ def list_devices(vid=None, pid=None, vendor=None, serial=None, *args,
     for device in context.list_devices(subsystem='tty'):
         if is_usb_serial(device, vid=vid, pid=pid, vendor=vendor,
                          serial=serial):
-            devs.append([device['ID_VENDOR_ID'], device['ID_MODEL_ID'],
+            devs.append([device.properties['ID_VENDOR_ID'], device.properties['ID_MODEL_ID'],
                          extra_info(device), device.device_node])
     return devs
 


### PR DESCRIPTION
I was getting some warnings in the output:
```
test.py:71: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
  devs.append([device['ID_VENDOR_ID'], device['ID_MODEL_ID'],
test.py:56: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
  extra_items.append("vendor '%s'" % device['ID_VENDOR'])
test.py:58: DeprecationWarning: Will be removed in 1.0. Access properties with Device.properties.
  extra_items.append("serial '%s'" % device['ID_SERIAL_SHORT'])
```

This PR fixes that.
