### PR TITLE
Non blocking read

### DIFF
--- a/usb_ser_mon/usb_ser_mon.py
+++ b/usb_ser_mon/usb_ser_mon.py
@@ -14,6 +14,7 @@ import select
 import pyudev
 import serial
 import sys
+import os
 import tty
 import termios
 import traceback
@@ -204,7 +205,7 @@ def usb_serial_mon(monitor, device, baud=115200, debug=False, echo=False):
                 sys.stdout.flush()
                 log.log(data)
             if fileno == sys.stdin.fileno():
-                data = sys.stdin.read(1)
+                data = os.read(fileno, 1)
                 if len(data) == 0:
                     continue
                 if debug:
@@ -307,7 +308,6 @@ def main():
         default=False
     )
     args = parser.parse_args(sys.argv[1:])
-    sys.stdin = sys.stdin.buffer
     sys.stdout = sys.stdout.buffer
 
     global log

--- a/usb_ser_mon/usb_ser_mon.py
+++ b/usb_ser_mon/usb_ser_mon.py
@@ -20,6 +20,7 @@ import traceback
 import syslog
 import argparse
 import time
+from collections import namedtuple
 
 EXIT_CHAR = 0
 def set_exit_char(exit_char):
@@ -358,7 +359,7 @@ def main():
 
         # Otherwise wait for the teensy device to connect
         while True:
-            dev = {}
+            dev = namedtuple('Device', ['properties'])({})
             if args.serial:
                 dev.properties['ID_SERIAL_SHORT'] = args.serial
             if args.vendor:


### PR DESCRIPTION
Hi Dave, it's me again. I found a small problem with the polling loop. If you try to send several characters from the keyboard very quickly (for example, by copy-pasting a block of text), epoll.poll() would return only one event for this incoming block. Then sys.stdin.read(1) would read the first character of this block, but the next call to epoll.poll() will block forever because there are no new events. Well, at least until you press the next key on the keyboard.

One of the ways to fix it would be to use non-blocking read from stdin, and read as many characters as possible before calling epoll.poll() again. Here is my version. I also fixed a small bug on line 363.

Regards,
Dima.

