### PR TITLE
Non blocking read

### DIFF
--- a/usb_ser_mon/usb_ser_mon.py
+++ b/usb_ser_mon/usb_ser_mon.py
@@ -14,6 +14,7 @@ import select
 import pyudev
 import serial
 import sys
+import os
 import tty
 import termios
 import traceback
@@ -204,7 +205,7 @@ def usb_serial_mon(monitor, device, baud=115200, debug=False, echo=False):
                 sys.stdout.flush()
                 log.log(data)
             if fileno == sys.stdin.fileno():
-                data = sys.stdin.read(1)
+                data = os.read(fileno, 1)
                 if len(data) == 0:
                     continue
                 if debug:
@@ -307,7 +308,6 @@ def main():
         default=False
     )
     args = parser.parse_args(sys.argv[1:])
-    sys.stdin = sys.stdin.buffer
     sys.stdout = sys.stdout.buffer
 
     global log

--- a/usb_ser_mon/usb_ser_mon.py
+++ b/usb_ser_mon/usb_ser_mon.py
@@ -20,6 +20,7 @@ import traceback
 import syslog
 import argparse
 import time
+from collections import namedtuple
 
 EXIT_CHAR = 0
 def set_exit_char(exit_char):
@@ -358,7 +359,7 @@ def main():
 
         # Otherwise wait for the teensy device to connect
         while True:
-            dev = {}
+            dev = namedtuple('Device', ['properties'])({})
             if args.serial:
                 dev.properties['ID_SERIAL_SHORT'] = args.serial
             if args.vendor:

--- a/usb_ser_mon/usb_ser_mon.py
+++ b/usb_ser_mon/usb_ser_mon.py
@@ -380,7 +380,7 @@ def main():
                                 debug=args.debug, echo=args.echo)
                             break
                     if fileno == sys.stdin.fileno():
-                        data = sys.stdin.read(1)
+                        data = os.read(fileno, 1)
                         if data[0] == EXIT_CHAR:
                             raise KeyboardInterrupt
     except KeyboardInterrupt:


### PR DESCRIPTION
When usb_ser_mon is waiting for the USB device to be connected, it's impossible to terminate it with Ctrl-X  because it's using sys.stdin.read() in the waiting mode. This change replaces sys.stdin.read with os.read, making it possible to recognise Ctrl-X and terminate gracefully.
